### PR TITLE
Fix external link in Banner

### DIFF
--- a/src/config.tsx
+++ b/src/config.tsx
@@ -1,5 +1,4 @@
 import { ExternalLink } from "lucide-react";
-import { Link } from "react-router-dom";
 import { cn } from "./lib/utils";
 
 const GITHUB_URL = "https://github.com/byrdocs/byrdocs-archive"
@@ -7,9 +6,14 @@ const GITHUB_URL = "https://github.com/byrdocs/byrdocs-archive"
 export function Banner({ className }: { className?: string }) {
     return (
         <div className={cn("w-full text-sm bg-secondary text-muted-foreground flex flex-row flex-wrap justify-center py-2", className)}>
-            <Link to={GITHUB_URL} target="_blank" className="text-primary/70 dark:text-primary hover:underline">
+            <a
+                href={GITHUB_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary/70 dark:text-primary hover:underline"
+            >
                 如果 BYR Docs 有帮助，Star 我们的 GitHub 仓库！
-            </Link>
+            </a>
             <div className="ml-1 flex items-center">
                 <ExternalLink size={12} />
             </div>


### PR DESCRIPTION
## Summary
- use an `<a>` tag for GitHub link so routing doesn't intercept external URLs

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_684b15a823d88320a8df02202763f71e