### PR TITLE
Fix LoadingIcon stroke-width

### DIFF
--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -9,7 +9,7 @@ export function LoadingIcon({ className }: { className?: string }) {
       className={cn("animate-spin w-20 h-20 mx-auto select-none", className)}
     >
       <g className="loading_spinner">
-        <circle cx="12" cy="12" r="9.5" fill="none" stroke-width="1"></circle>
+        <circle cx="12" cy="12" r="9.5" fill="none" strokeWidth="1"></circle>
       </g>
     </svg>
   );


### PR DESCRIPTION
## Summary
- use `strokeWidth` attribute for the `<circle>` in `LoadingIcon`

## Testing
- `pnpm lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_684b177a6aa08320a1aa9bcf12d3ae85